### PR TITLE
sqleditions - 2.4.x

### DIFF
--- a/lib/FusionInventory/Agent/Task/Inventory/Win32/Softwares.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Win32/Softwares.pm
@@ -353,12 +353,10 @@ sub _getSqlEdition {
     return unless $sqlinstancesList;
 
     # List of SQL Instances
-    foreach my $sqlinstance (keys %$sqlinstancesList) {
-        my $sqlinstanceName = $sqlinstance;
-        my $sqlinstanceValue = $sqlinstancesList->{$sqlinstance};
+    foreach my $sqlinstanceName (keys %$sqlinstancesList) {
+        my $sqlinstanceValue = $sqlinstancesList->{$sqlinstanceName};
         # Get version and edition for each instance
         my ($sqlinstanceEditionValue,$sqlinstanceVersionValue) = _getSqlInstancesVersions(
-            %params,
             SOFTVERSION => $softwareVersion,
             NAME        => $sqlinstanceName,
             VALUE       => $sqlinstanceValue

--- a/lib/FusionInventory/Agent/Task/Inventory/Win32/Softwares.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Win32/Softwares.pm
@@ -232,6 +232,27 @@ sub _getSoftwaresList {
             $software->{INSTALLDATE} = _dateFormat(_keyLastWriteDateString($data));
         }
 
+        #----- SQL Server -----
+        # Versions >= SQL Server 2008 (tested with 2008/R2/2012/2016) : "SQL Server xxxx Database Engine Services"
+        if ($software->{NAME} =~ /^(SQL Server.*)(\sDatabase Engine Services)/) {
+            my $sqlEditionValue = _getSqlInstancesList(
+                softwarename    => $software->{NAME},
+                softwareversion => $software->{VERSION}
+            );
+            if (defined($sqlEditionValue)) {$software->{NAME} = "$1 " . $sqlEditionValue . "$2";}
+            $logger->info("-------------");
+        # Versions = SQL Server 2005 : "Microsoft SQL Server xxxx"
+        # "Uninstall" registry key does not contains Version : use default named instance.
+        } elsif ($software->{NAME} =~ /^(Microsoft SQL Server 200[0-9])$/ and defined($software->{VERSION})) {
+            my $sqlEditionValue = _getSqlInstancesList(
+                softwarename    => $software->{NAME},
+                softwareversion => $software->{VERSION}
+            );
+            if (defined($sqlEditionValue)) {$software->{NAME} = "$1 " . $sqlEditionValue;}
+            $logger->info("-------------");
+        }
+        #----------
+
         push @list, $software;
     }
 
@@ -314,6 +335,69 @@ sub _processMSIE {
         }
     );
 
+}
+
+# List of SQL Instances
+sub _getSqlInstancesList {
+    my (%params) = @_;
+
+    my $softwareName = $params{softwarename};
+    my $softwareVersion = $params{softwareversion};
+
+    # Registry access for SQL Instances
+    my $sqlinstancesList = getRegistryKey(
+        path    => "HKEY_LOCAL_MACHINE/SOFTWARE/Microsoft/Microsoft SQL Server/Instance Names/SQL",
+        wmiopts => { # Only used for remote WMI optimization
+            values  => [ qw/
+                DisplayName Comments HelpLink ReleaseType DisplayVersion
+                Publisher URLInfoAbout UninstallString InstallDate MinorVersion
+                MajorVersion NoRemove SystemComponent
+                / ]
+        },
+        %params
+    ) or return;
+
+    # List of SQL Instances
+    foreach my $sqlinstance (keys %$sqlinstancesList) {
+        my $sqlinstanceName = $sqlinstance;
+        my $sqlinstanceValue = $sqlinstancesList->{$sqlinstance};
+        # Get version and edition for each instance
+        my ($sqlinstanceEditionValue,$sqlinstanceVersionValue) = _getSqlInstancesVersions(
+            %params,
+            SOFTVERSION => $softwareVersion,
+            NAME        => $sqlinstanceName,
+            VALUE       => $sqlinstanceValue
+        );
+        next unless $sqlinstanceEditionValue && $sqlinstanceVersionValue;
+        if ($softwareVersion eq $sqlinstanceVersionValue) {return $sqlinstanceEditionValue;} 
+    }
+}
+
+# SQL Instances versions
+# Return version and edition for each instance
+sub _getSqlInstancesVersions {
+    my (%params) = @_;
+
+    my $softwareVersion = $params{SOFTVERSION};	
+    my $sqlinstanceName = $params{NAME};
+    my $sqlinstanceValue = $params{VALUE};
+
+    my $sqlinstanceVersions = getRegistryKey(
+        path    => "HKEY_LOCAL_MACHINE/SOFTWARE/Microsoft/Microsoft SQL Server/" . $sqlinstanceValue . "/Setup",
+        wmiopts => { # Only used for remote WMI optimization
+            values  => [ qw/
+                DisplayName Comments HelpLink ReleaseType DisplayVersion
+                Publisher URLInfoAbout UninstallString InstallDate MinorVersion
+                MajorVersion NoRemove SystemComponent
+                / ]
+        },
+        %params
+    );
+
+    my $sqlinstanceVersionValue = $sqlinstanceVersions->{'/Version'} or return;
+    my $sqlinstanceEditionValue = $sqlinstanceVersions->{'/Edition'};
+    # If software version match instance one
+    if ($softwareVersion eq $sqlinstanceVersionValue) {return ($sqlinstanceEditionValue,$sqlinstanceVersionValue);}
 }
 
 1;

--- a/lib/FusionInventory/Agent/Task/Inventory/Win32/Softwares.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Win32/Softwares.pm
@@ -235,22 +235,22 @@ sub _getSoftwaresList {
         #----- SQL Server -----
         # Versions >= SQL Server 2008 (tested with 2008/R2/2012/2016) : "SQL Server xxxx Database Engine Services"
         if ($software->{NAME} =~ /^(SQL Server.*)(\sDatabase Engine Services)/) {
-            my $sqlEditionValue = _getSqlInstancesList(
+            my $sqlEditionValue = _getSqlEdition(
                 softwarename    => $software->{NAME},
                 softwareversion => $software->{VERSION}
             );
             if (defined($sqlEditionValue)) {
-                $software->{NAME} = "$1 " . $sqlEditionValue . "$2";
+                $software->{NAME} = $1." ".$sqlEditionValue.$2;
             }
         # Versions = SQL Server 2005 : "Microsoft SQL Server xxxx"
         # "Uninstall" registry key does not contains Version : use default named instance.
         } elsif ($software->{NAME} =~ /^(Microsoft SQL Server 200[0-9])$/ and defined($software->{VERSION})) {
-            my $sqlEditionValue = _getSqlInstancesList(
+            my $sqlEditionValue = _getSqlEdition(
                 softwarename    => $software->{NAME},
                 softwareversion => $software->{VERSION}
             );
             if (defined($sqlEditionValue)) {
-                $software->{NAME} = "$1 " . $sqlEditionValue;
+                $software->{NAME} = $1." ".$sqlEditionValue;
             }
         }
         #----------
@@ -340,7 +340,7 @@ sub _processMSIE {
 }
 
 # List of SQL Instances
-sub _getSqlInstancesList {
+sub _getSqlEdition {
     my (%params) = @_;
 
     my $softwareName = $params{softwarename};
@@ -348,9 +348,9 @@ sub _getSqlInstancesList {
 
     # Registry access for SQL Instances
     my $sqlinstancesList = getRegistryKey(
-        path    => "HKEY_LOCAL_MACHINE/SOFTWARE/Microsoft/Microsoft SQL Server/Instance Names/SQL",
-        %params
-    ) or return;
+        path    => "HKEY_LOCAL_MACHINE/SOFTWARE/Microsoft/Microsoft SQL Server/Instance Names/SQL"
+    );
+    return unless $sqlinstancesList;
 
     # List of SQL Instances
     foreach my $sqlinstance (keys %$sqlinstancesList) {
@@ -379,9 +379,9 @@ sub _getSqlInstancesVersions {
     my $sqlinstanceValue = $params{VALUE};
 
     my $sqlinstanceVersions = getRegistryKey(
-        path    => "HKEY_LOCAL_MACHINE/SOFTWARE/Microsoft/Microsoft SQL Server/" . $sqlinstanceValue . "/Setup",
-        %params
+        path    => "HKEY_LOCAL_MACHINE/SOFTWARE/Microsoft/Microsoft SQL Server/" . $sqlinstanceValue . "/Setup"
     );
+    return unless $sqlinstanceVersions;
 
     my $sqlinstanceVersionValue = $sqlinstanceVersions->{'/Version'} or return;
     my $sqlinstanceEditionValue = $sqlinstanceVersions->{'/Edition'};

--- a/lib/FusionInventory/Agent/Task/Inventory/Win32/Softwares.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/Win32/Softwares.pm
@@ -239,8 +239,9 @@ sub _getSoftwaresList {
                 softwarename    => $software->{NAME},
                 softwareversion => $software->{VERSION}
             );
-            if (defined($sqlEditionValue)) {$software->{NAME} = "$1 " . $sqlEditionValue . "$2";}
-            $logger->info("-------------");
+            if (defined($sqlEditionValue)) {
+                $software->{NAME} = "$1 " . $sqlEditionValue . "$2";
+            }
         # Versions = SQL Server 2005 : "Microsoft SQL Server xxxx"
         # "Uninstall" registry key does not contains Version : use default named instance.
         } elsif ($software->{NAME} =~ /^(Microsoft SQL Server 200[0-9])$/ and defined($software->{VERSION})) {
@@ -248,8 +249,9 @@ sub _getSoftwaresList {
                 softwarename    => $software->{NAME},
                 softwareversion => $software->{VERSION}
             );
-            if (defined($sqlEditionValue)) {$software->{NAME} = "$1 " . $sqlEditionValue;}
-            $logger->info("-------------");
+            if (defined($sqlEditionValue)) {
+                $software->{NAME} = "$1 " . $sqlEditionValue;
+            }
         }
         #----------
 
@@ -347,13 +349,6 @@ sub _getSqlInstancesList {
     # Registry access for SQL Instances
     my $sqlinstancesList = getRegistryKey(
         path    => "HKEY_LOCAL_MACHINE/SOFTWARE/Microsoft/Microsoft SQL Server/Instance Names/SQL",
-        wmiopts => { # Only used for remote WMI optimization
-            values  => [ qw/
-                DisplayName Comments HelpLink ReleaseType DisplayVersion
-                Publisher URLInfoAbout UninstallString InstallDate MinorVersion
-                MajorVersion NoRemove SystemComponent
-                / ]
-        },
         %params
     ) or return;
 
@@ -369,7 +364,8 @@ sub _getSqlInstancesList {
             VALUE       => $sqlinstanceValue
         );
         next unless $sqlinstanceEditionValue && $sqlinstanceVersionValue;
-        if ($softwareVersion eq $sqlinstanceVersionValue) {return $sqlinstanceEditionValue;} 
+        return $sqlinstanceEditionValue
+            if ($softwareVersion eq $sqlinstanceVersionValue); 
     }
 }
 
@@ -384,20 +380,14 @@ sub _getSqlInstancesVersions {
 
     my $sqlinstanceVersions = getRegistryKey(
         path    => "HKEY_LOCAL_MACHINE/SOFTWARE/Microsoft/Microsoft SQL Server/" . $sqlinstanceValue . "/Setup",
-        wmiopts => { # Only used for remote WMI optimization
-            values  => [ qw/
-                DisplayName Comments HelpLink ReleaseType DisplayVersion
-                Publisher URLInfoAbout UninstallString InstallDate MinorVersion
-                MajorVersion NoRemove SystemComponent
-                / ]
-        },
         %params
     );
 
     my $sqlinstanceVersionValue = $sqlinstanceVersions->{'/Version'} or return;
     my $sqlinstanceEditionValue = $sqlinstanceVersions->{'/Edition'};
     # If software version match instance one
-    if ($softwareVersion eq $sqlinstanceVersionValue) {return ($sqlinstanceEditionValue,$sqlinstanceVersionValue);}
+    return ($sqlinstanceEditionValue,$sqlinstanceVersionValue)
+        if ($softwareVersion eq $sqlinstanceVersionValue);
 }
 
 1;


### PR DESCRIPTION
Recover Edition value for SQL Server Engine and add it to the Engine name (tested with multiples instances/versions/editions) :

    SQL Server >= 2008 : "SQL Server 2008 Database Engine Services"
    e.g. : "SQL Server 2008 R2 Standard Edition Database Engine Services"
    SQL Server = 2005 : "Microsoft SQL Server 2005
    e.g. : "Microsoft SQL Server 2005 Express Edition"

Purpose is to use glpi rules to get differents versions/editions for each engine and separate Express/Standard/Enterprise for licensing.
[instances_names.reg.txt](https://github.com/keyser75000/fusioninventory-agent/files/1547890/instances_names.reg.txt)
[sqlexpr_instance.reg.txt](https://github.com/keyser75000/fusioninventory-agent/files/1547891/sqlexpr_instance.reg.txt)
[sqlstd_instance.reg.txt](https://github.com/keyser75000/fusioninventory-agent/files/1547892/sqlstd_instance.reg.txt)
